### PR TITLE
Remove IPv6 dependency from unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,25 +8,32 @@ matrix:
       env: DO_COVERAGE=no
 
 before_install:
-  - sudo apt-get update
+  - sudo apt-get update -qq
 
 install:
   - sudo apt-get install build-essential libssl-dev libz-dev libsqlite3-dev libcurl4-gnutls-dev libdaemon-dev automake autoconf pkg-config libtool libcppunit-dev libnl-3-dev libnl-cli-3-dev libnl-genl-3-dev libnl-nf-3-dev libnl-route-3-dev libarchive-dev
-  - sudo pip install cpp-coveralls
+  - if [ "${DO_COVERAGE}" == "yes" ]; then
+      sudo pip install cpp-coveralls;
+    fi
 
 before_script:
   - cd ibrdtn
 
 script:
+  - CONFIGURE_OPTS="--with-cppunit --with-openssl --with-curl --with-lowpan --with-sqlite --with-compression --with-xml --with-tls --with-dht --enable-debug --disable-netlink"
   - ./autogen.sh
-  - ./configure-dev --disable-netlink --enable-gcov
+  - if [ "${DO_COVERAGE}" == "yes" ]; then
+      ./configure-dev ${CONFIGURE_OPTS} --enable-gcov;
+    else
+      ./configure-dev ${CONFIGURE_OPTS};
+    fi
   - make
   - make check
 
 after_success:
   - rm ibrdtn/ibrcommon; mv ibrcommon ibrdtn/ibrcommon
-  - rm $(find -name '*.gcno' | grep -v '.libs')
   - if [ "${DO_COVERAGE}" == "yes" ]; then
+      rm $(find -name '*.gcno' | grep -v '.libs');
       coveralls -r $(pwd)/ibrdtn --exclude ibrcommon/tests --exclude ibrdtn/tests --exclude daemon/tests --exclude tools --gcov-options '\-lp';
     fi
 

--- a/ibrcommon/tests/net/tcpstreamtest.cpp
+++ b/ibrcommon/tests/net/tcpstreamtest.cpp
@@ -69,7 +69,7 @@ void tcpstreamtest::runTest()
 	char values[10] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
 	try {
-		ibrcommon::vaddress addr("::1", 4343);
+		ibrcommon::vaddress addr("127.0.0.1", 4343);
 		ibrcommon::socketstream client(new ibrcommon::tcpsocket(addr));
 
 		// send some data

--- a/ibrdtn/ibrdtn/tests/net/TestStreamConnection.cpp
+++ b/ibrdtn/ibrdtn/tests/net/TestStreamConnection.cpp
@@ -226,7 +226,7 @@ void TestStreamConnection::connectionUpDown()
 	// start the server thread
 	srv.start();
 
-	ibrcommon::vaddress addr("::1", 1234);
+	ibrcommon::vaddress addr("127.0.0.1", 1234);
 	ibrcommon::socketstream conn(new ibrcommon::tcpsocket(addr));
 	testclient cl(conn);
 


### PR DESCRIPTION
In unit-tests IPv6 loopback addresses were used to test server and client components locally. This is no longer supported on testing infrastructure of Travis CI. Therefore the dependency is removed within this change-set.