### PR TITLE
ssl: Fix compilation without deprecated OpenSSL 1.1 APIs

### DIFF
--- a/ibrcommon/ibrcommon/ssl/TLSStream.cpp
+++ b/ibrcommon/ibrcommon/ssl/TLSStream.cpp
@@ -259,16 +259,22 @@ namespace ibrcommon
 		/* openssl initialization */
 		/* the if block is needed because SSL_library_init() is not reentrant */
 		if(!_SSL_initialized){
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 			SSL_load_error_strings();
 			SSL_library_init();
 			ERR_load_BIO_strings();
 			ERR_load_SSL_strings();
+#endif
 			_SSL_initialized = true;
 		}
 
 
 		/* create ssl context and throw exception if it fails */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 		_ssl_ctx = SSL_CTX_new(TLSv1_method());
+#else
+		_ssl_ctx = SSL_CTX_new(TLS_method());
+#endif
 		if(!_ssl_ctx){
 			char err_buf[ERR_BUF_SIZE];
 			ERR_error_string_n(ERR_get_error(), err_buf, ERR_BUF_SIZE);


### PR DESCRIPTION
I'm not sure the original code is correct by calling TLSv1_method and not SSLv23. TLSv1 keeps it at TLS 1.0. No further. This is fixed in 1.0.2 by calling SSLv23_method and SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);